### PR TITLE
Support DNS

### DIFF
--- a/op-signer/service/auth.go
+++ b/op-signer/service/auth.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"net"
 	"net/http"
 
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
@@ -27,22 +26,11 @@ func NewAuthMiddleware() oprpc.Middleware {
 				return
 			}
 			// Note that the certificate is already verified by http server if we get here
-			if len(peerTlsInfo.LeafCertificate.IPAddresses) < 1 {
-				http.Error(w, "client certificate verified but did not contain IP SAN extension", 401)
+			if len(peerTlsInfo.LeafCertificate.DNSNames) < 1 {
+				http.Error(w, "client certificate verified but did not contain DNS SAN extension", 401)
 				return
 			}
-			certIP := peerTlsInfo.LeafCertificate.IPAddresses[0].String()
-			reqIP, _, err := net.SplitHostPort(r.RemoteAddr)
-			if err != nil {
-				http.Error(w, "failed to parse remote address", 400)
-				return
-			}
-			// Check that the IP in the client certificate matches the remote IP address from the request
-			if certIP != reqIP {
-				http.Error(w, "client certificate IP does not match remote address", 401)
-				return
-			}
-			clientInfo.ClientName = certIP
+			clientInfo.ClientName = peerTlsInfo.LeafCertificate.DNSNames[0]
 
 			ctx := context.WithValue(r.Context(), clientInfoContextKey{}, clientInfo)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/op-signer/tls.sh
+++ b/op-signer/tls.sh
@@ -2,7 +2,7 @@
 
 # ------------------------------------------------------------------------------
 # Usage:
-# ./tls.sh server|client <IP address>
+# ./tls.sh server|client <Domain Name>
 # ------------------------------------------------------------------------------
 
 set -e
@@ -14,15 +14,15 @@ if [[ "${VERSION}" != "OpenSSL 3."* ]]; then
 fi
 
 if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 [server|client] <IP address>"
+    echo "Usage: $0 [server|client] <Domain Name>"
     exit 1
 fi
 
 MODE=$1
-IP_ADDRESS=$2
+DNS_NAME=$2
 CA_SUBJECT="/O=SWC/CN=SWC root CA"
 SUBJECT="/O=SWC/CN=SWC op-signer $MODE"
-ALT_NAME="IP:${IP_ADDRESS}"
+ALT_NAME="DNS:${DNS_NAME}"
 DAYS_VALID="3650"
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 TLS_DIR_SERVER="${SCRIPT_DIR}/tls-server"
@@ -47,7 +47,7 @@ case $MODE in
             -out ca.crt \
             -subj "${CA_SUBJECT}"
         fi
-        ALT_NAME="DNS:localhost,IP:${IP_ADDRESS}"
+        ALT_NAME="DNS:localhost,DNS:${DNS_NAME}"
         ;;
     client)
         if [[ ! -f "ca.crt" ]]; then


### PR DESCRIPTION
Use DNS names instead of IP addresses to address situations where multiple clients are deployed on a single machine.